### PR TITLE
Change FerrisEpoch (rewrite branch)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,7 +38,7 @@ export function parseCSSColor(color: string, forceAlpha?: number) {
     }
 }
 
-export const FERRIS_EPOCH_MS: number = 1_577_836_800_000;
+export const FERRIS_EPOCH_MS: number = 1_641_016_800_000;
 const BIGINT_64: bigint = BigInt(64);  // Some browsers do not support bigint literals (e.g. 64n)
 
 export function parseSnowflake(snowflake: string | bigint): Date {


### PR DESCRIPTION
This PR changes the Ferris Epoch to 1641016800000ms after unix Epoch (1/1/2022 00:00:00.000000 -0600).

This will be merged on 12/31/2021 at 2345.

Library Maintainers, please test and approve this before the merge date. If there is a problem please LET ME KNOW ASAP.

Signed-off-by: hydrostaticcog <hydro@hydrostaticcog.me>